### PR TITLE
Added link for API server (Update README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Note that there are some things you cannot do, such as updating the internal ide
 * https://davidmegginson.github.io/ourairports-data/navaids.csv
 * https://davidmegginson.github.io/ourairports-data/countries.csv
 * https://davidmegginson.github.io/ourairports-data/regions.csv
+
+## Self hosted API Server
+* [vacxe/airports-info-api](https://github.com/Vacxe/airports-info-api)


### PR DESCRIPTION
I'm just a little bit confused how [https://airportdb.io/](https://airportdb.io/) using the data from this site (and it looks so outdated). 

I just created and published self hosted API server and Docker for it. If you want, you can add link to my page for the reference. Cheers.